### PR TITLE
Add support to ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 dist: xenial
 sudo: required
 language: C
+arch:
+  - amd64
+  - ppc64le
 compiler:
   - gcc
   #- clang


### PR DESCRIPTION
Add support to Linux on Power Little Endian architecture. tenace is part of the ubuntu distribution on ppc64le as well. Continuously building/testing it on this platform along with intel (amd64) will help identifying/fixing the issues in early stage.